### PR TITLE
Correctly quote attribute selectors.

### DIFF
--- a/src/components/hash.js
+++ b/src/components/hash.js
@@ -6,7 +6,7 @@
 
 	'use strict';
 	var $jmpress = $.jmpress,
-		hashLink = "a[href^=#]";
+		hashLink = "a[href^='#']";
 
 	/* FUNCTIONS */
 	function randomString() {


### PR DESCRIPTION
Fixes jmpressjs/jmpress.js#185

(apologies for the line ending change, at EOF I'm doing this via the web editor on GitHub and it automatically added it -- I don't think I can correct it here)

See:
https://github.com/jquery/jquery/commit/41f522ace1518f7f6f22f2e227350b0bdf78e62b
https://github.com/jquery/jquery/issues/2824
https://github.com/jquery/api.jquery.com/issues/910
